### PR TITLE
Forbid value and filterable to be nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- Forbid `Value` and `Filterable` to be nested
 
 ## 1.0.0 - 2018-08-28
 - Initial version.

--- a/src/Entity/Filterable.php
+++ b/src/Entity/Filterable.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\ApiFilter\Entity;
 
+use Assert\Assertion;
+
 class Filterable
 {
     /** @var mixed */
@@ -10,6 +12,11 @@ class Filterable
     /** @param mixed $value This must be supported by any applicator */
     public function __construct($value)
     {
+        Assertion::notIsInstanceOf(
+            $value,
+            self::class,
+            'Filterable must not contain another Filterable. Extract a value from Filterable or use it directly.'
+        );
         $this->value = $value;
     }
 

--- a/src/Entity/Value.php
+++ b/src/Entity/Value.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\ApiFilter\Entity;
 
+use Assert\Assertion;
+
 class Value
 {
     /** @var mixed */
@@ -10,6 +12,11 @@ class Value
     /** @param mixed $value Value of different types */
     public function __construct($value)
     {
+        Assertion::notIsInstanceOf(
+            $value,
+            self::class,
+            'Value must not contain another Value. Extract a value from Value or use it directly.'
+        );
         $this->value = $value;
     }
 

--- a/tests/Entity/FilterableTest.php
+++ b/tests/Entity/FilterableTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\ApiFilter\Entity;
+
+use Lmc\ApiFilter\AbstractTestCase;
+
+class FilterableTest extends AbstractTestCase
+{
+    /**
+     * @test
+     * @dataProvider provideValidFilterable
+     *
+     * @param mixed $validFilterable of type <T>
+     */
+    public function shouldCreateFilterable($validFilterable): void
+    {
+        $filterable = new Filterable($validFilterable);
+
+        $this->assertSame($validFilterable, $filterable->getValue());
+    }
+
+    public function provideValidFilterable(): array
+    {
+        return [
+            // validValue
+            'null' => [null],
+            'string' => ['string'],
+            'int' => [42],
+            'float' => [4.2],
+            'bool' => [true],
+            'array' => [[1, 'two', 3.3]],
+            'value' => [new Value('foo')],
+            'query builder' => [$this->setUpQueryBuilder('t')],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreateFilterableFromFilterable(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Filterable must not contain another Filterable. Extract a value from Filterable or use it directly.');
+
+        new Filterable(new Filterable('nested filterable'));
+    }
+}

--- a/tests/Entity/ValueTest.php
+++ b/tests/Entity/ValueTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\ApiFilter\Entity;
+
+use Lmc\ApiFilter\AbstractTestCase;
+
+class ValueTest extends AbstractTestCase
+{
+    /**
+     * @test
+     * @dataProvider provideValidValue
+     *
+     * @param mixed $validValue of type <T>
+     */
+    public function shouldCreateValue($validValue): void
+    {
+        $value = new Value($validValue);
+
+        $this->assertSame($validValue, $value->getValue());
+    }
+
+    public function provideValidValue(): array
+    {
+        return [
+            // validValue
+            'null' => [null],
+            'string' => ['string'],
+            'int' => [42],
+            'float' => [4.2],
+            'bool' => [true],
+            'array' => [[1, 'two', 3.3]],
+            'object' => [new Filterable('foo')],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreateValueFromValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must not contain another Value. Extract a value from Value or use it directly.');
+
+        new Value(new Value('nested value'));
+    }
+}


### PR DESCRIPTION
This is a safety check for not nesting these entites by mistake (_or on purpose, since it doesn't really make any sense_).
