### PR TITLE
Add parser for single column and array value

### DIFF
--- a/src/Service/Parser/SingleColumnArrayValueParser.php
+++ b/src/Service/Parser/SingleColumnArrayValueParser.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\ApiFilter\Service\Parser;
+
+class SingleColumnArrayValueParser extends AbstractParser
+{
+    public function supports(string $rawColumn, $rawValue): bool
+    {
+        return !$this->isTuple($rawColumn) && is_array($rawValue);
+    }
+
+    public function parse(string $rawColumn, $rawValue): iterable
+    {
+        foreach ($rawValue as $filter => $value) {
+            yield $this->createFilter($rawColumn, $filter, $value);
+        }
+    }
+}

--- a/src/Service/QueryParametersParser.php
+++ b/src/Service/QueryParametersParser.php
@@ -8,6 +8,7 @@ use Lmc\ApiFilter\Exception\TupleException;
 use Lmc\ApiFilter\Filters\Filters;
 use Lmc\ApiFilter\Filters\FiltersInterface;
 use Lmc\ApiFilter\Service\Parser\ParserInterface;
+use Lmc\ApiFilter\Service\Parser\SingleColumnArrayValueParser;
 use Lmc\ApiFilter\Service\Parser\SingleColumnSingleValueParser;
 use MF\Collection\Exception\TupleExceptionInterface;
 use MF\Collection\Immutable\ITuple;
@@ -30,6 +31,7 @@ class QueryParametersParser
         $this->filterFactory = $filterFactory;
 
         $this->parsers = new PrioritizedCollection(ParserInterface::class);
+        $this->parsers->add(new SingleColumnArrayValueParser($filterFactory), 2);
         $this->parsers->add(new SingleColumnSingleValueParser($filterFactory), 1);
     }
 

--- a/tests/Service/Parser/SingleColumnArrayValueParserTest.php
+++ b/tests/Service/Parser/SingleColumnArrayValueParserTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\ApiFilter\Service\Parser;
+
+/**
+ * @covers \Lmc\ApiFilter\Service\Parser\SingleColumnArrayValueParser
+ */
+class SingleColumnArrayValueParserTest extends AbstractParserTestCase
+{
+    protected function setUp(): void
+    {
+        $this->parser = new SingleColumnArrayValueParser($this->mockFilterFactory());
+    }
+
+    public function provideNotSupportedColumnAndValue(): array
+    {
+        return self::CASE_SCALAR_COLUMN_AND_SCALAR_VALUE
+            + self::CASE_TUPLE_COLUMN_WITH_FILTER_AND_TUPLE_VALUE
+            + self::CASE_TUPLE_COLUMN_AND_TUPLE_VALUE
+            + self::CASE_TUPLE_COLUMN_AND_TUPLE_VALUE_IMPLICIT_FILTERS
+            + self::CASE_SCALAR_COLUMN_AND_TUPLE_VALUE
+            + self::CASE_TUPLE_COLUMN_AND_SCALAR_VALUE
+            + self::CASE_TUPLE_COLUMN_AND_ARRAY_VALUE;
+    }
+
+    public function provideParseableColumnAndValue(): array
+    {
+        return self::CASE_SCALAR_COLUMN_AND_ARRAY_VALUE
+            + self::CASE_SCALAR_COLUMN_AND_ARRAY_VALUES;
+    }
+}

--- a/tests/Service/QueryParametersParserTest.php
+++ b/tests/Service/QueryParametersParserTest.php
@@ -75,9 +75,9 @@ class QueryParametersParserTest extends AbstractTestCase
             'one col more filters + other col - explicit/implicit' => [
                 ['title' => ['gt' => '0', 'lt' => '10'], 'value' => 'foo'],
                 [
-                    new FilterWithOperator('value', new Value('foo'), '=', 'eq'),
                     new FilterWithOperator('title', new Value('0'), '>', 'gt'),
                     new FilterWithOperator('title', new Value('10'), '<', 'lt'),
+                    new FilterWithOperator('value', new Value('foo'), '=', 'eq'),
                 ],
             ],
             'one col - between - explicit' => [
@@ -103,9 +103,9 @@ class QueryParametersParserTest extends AbstractTestCase
             'tuple - implicit eq + explicit in' => [
                 ['(zone,bucket)' => '(lmc,all)', 'id' => ['in' => [1, 2, 3]]],
                 [
+                    new FilterIn('id', new Value([1, 2, 3])),
                     new FilterWithOperator('zone', new Value('lmc'), '=', 'eq'),
                     new FilterWithOperator('bucket', new Value('all'), '=', 'eq'),
-                    new FilterIn('id', new Value([1, 2, 3])),
                 ],
             ],
             'tuple - between - explicit in values' => [


### PR DESCRIPTION
FYI: changes in the order of parsed filters in `QueryParameterParserTest` is because of deprecated backward compatibility - separated filters are executed first, and fallbacks later.