### PR TITLE
Add parameter definition

### DIFF
--- a/src/Entity/ParameterDefinition.php
+++ b/src/Entity/ParameterDefinition.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\ApiFilter\Entity;
+
+use Lmc\ApiFilter\Assertion;
+use Lmc\ApiFilter\Constant\Filter;
+use Lmc\ApiFilter\Filter\FunctionParameter;
+
+class ParameterDefinition
+{
+    /** @var string */
+    private $name;
+    /** @var string */
+    private $filter;
+    /** @var string */
+    private $column;
+    /** @var ?Value */
+    private $defaultValue;
+
+    /**
+     * Shortcut for creating parameter with just a name and a default value
+     * Otherwise you would need to pass null as filter and column, or create default values for yourself
+     *
+     * @example
+     * equalToDefaultValue('name', new Value(10))   // Parameter { name: "name", filter: "eq", column: "name",  defaultValue: Value(10) }
+     *
+     * ☝️is same as 👇
+     * fromArray(['name', null, null, 10])          // Parameter { name: "name", filter: "eq", column: "name",  defaultValue: Value(10) }
+     */
+    public static function equalToDefaultValue(string $name, Value $defaultValue): self
+    {
+        return new self($name, null, null, $defaultValue);
+    }
+
+    /**
+     * This method is basically a syntax sugar around the constructor method, but it wraps a default value into Value object
+     *
+     * @example
+     * fromArray(['name'])                    // Parameter { name: "name", filter: "eq", column: "name",  defaultValue: null }
+     * fromArray(['name', 'gt'])              // Parameter { name: "name", filter: "gt", column: "name",  defaultValue: null }
+     * fromArray(['name', 'gt', 'field'])     // Parameter { name: "name", filter: "gt", column: "field", defaultValue: null }
+     * fromArray(['name', null, 'field'])     // Parameter { name: "name", filter: "eq", column: "field", defaultValue: null }
+     * fromArray(['name', 'gt', 'field', 10]) // Parameter { name: "name", filter: "gt", column: "field", defaultValue: Value(10) }
+     * fromArray(['name', null, null, 10])    // Parameter { name: "name", filter: "eq", column: "name",  defaultValue: Value(10) }
+     */
+    public static function fromArray(array $parameters): self
+    {
+        if (count($parameters) === 4) {
+            $defaultValue = array_pop($parameters);
+            $parameters[] = new Value($defaultValue);
+        }
+
+        return new self(...$parameters);
+    }
+
+    public function __construct(
+        string $name,
+        ?string $filter = Filter::EQUALS,
+        ?string $column = null,
+        ?Value $defaultValue = null
+    ) {
+        $this->name = $name;
+        $this->filter = $filter ?? Filter::EQUALS;
+        $this->column = $column ?? $name;
+        $this->defaultValue = $defaultValue;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getFilter(): string
+    {
+        return $this->filter;
+    }
+
+    public function getColumn(): string
+    {
+        return $this->column;
+    }
+
+    public function getDefaultValue(): Value
+    {
+        Assertion::notNull($this->defaultValue, sprintf('Default value is not set for "%s".', $this->name));
+
+        return $this->defaultValue;
+    }
+
+    public function hasDefaultValue(): bool
+    {
+        return $this->defaultValue !== null;
+    }
+
+    public function getTitleForDefaultValue(): string
+    {
+        return sprintf('%s_%s', $this->getName(), FunctionParameter::TITLE);
+    }
+}

--- a/tests/Entity/ParameterDefinitionTest.php
+++ b/tests/Entity/ParameterDefinitionTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\ApiFilter\Entity;
+
+use Lmc\ApiFilter\AbstractTestCase;
+use Lmc\ApiFilter\Exception\InvalidArgumentException;
+
+class ParameterDefinitionTest extends AbstractTestCase
+{
+    /**
+     * @test
+     */
+    public function shouldCreateParameterWithDefaults(): void
+    {
+        $parameter = new ParameterDefinition('foo');
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('foo', $parameter->getColumn());
+        $this->assertSame('eq', $parameter->getFilter());
+        $this->assertFalse($parameter->hasDefaultValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateParameterWithAllValues(): void
+    {
+        $defaultValue = new Value('boo');
+        $parameter = new ParameterDefinition('foo', 'gte', 'bar', $defaultValue);
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('bar', $parameter->getColumn());
+        $this->assertSame('gte', $parameter->getFilter());
+        $this->assertTrue($parameter->hasDefaultValue());
+        $this->assertSame($defaultValue, $parameter->getDefaultValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateParameterByArray(): void
+    {
+        $parameter = ParameterDefinition::fromArray(['foo', 'gte', 'bar', 'boo']);
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('bar', $parameter->getColumn());
+        $this->assertSame('gte', $parameter->getFilter());
+        $this->assertTrue($parameter->hasDefaultValue());
+        $this->assertSame('boo', $parameter->getDefaultValue()->getValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateParameterByArrayWithDefaults(): void
+    {
+        $parameter = ParameterDefinition::fromArray(['foo']);
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('foo', $parameter->getColumn());
+        $this->assertSame('eq', $parameter->getFilter());
+        $this->assertFalse($parameter->hasDefaultValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateParameterWithDefaultsAndDefaultValue(): void
+    {
+        $defaultValue = new Value('bar');
+        $parameter = new ParameterDefinition('foo', null, null, $defaultValue);
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('foo', $parameter->getColumn());
+        $this->assertSame('eq', $parameter->getFilter());
+        $this->assertTrue($parameter->hasDefaultValue());
+        $this->assertSame($defaultValue, $parameter->getDefaultValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateParameterByArrayWithDefaultsAndDefaultValue(): void
+    {
+        $parameter = ParameterDefinition::fromArray(['foo', null, null, 'bar']);
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('foo', $parameter->getColumn());
+        $this->assertSame('eq', $parameter->getFilter());
+        $this->assertTrue($parameter->hasDefaultValue());
+        $this->assertSame('bar', $parameter->getDefaultValue()->getValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateParameterWithDefaultValueOnly(): void
+    {
+        $defaultValue = new Value('bar');
+        $parameter = ParameterDefinition::equalToDefaultValue('foo', $defaultValue);
+
+        $this->assertSame('foo', $parameter->getName());
+        $this->assertSame('foo', $parameter->getColumn());
+        $this->assertSame('eq', $parameter->getFilter());
+        $this->assertTrue($parameter->hasDefaultValue());
+        $this->assertSame($defaultValue, $parameter->getDefaultValue());
+        $this->assertSame('foo_function_parameter', $parameter->getTitleForDefaultValue());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotGetDefaultValueIfNotSet(): void
+    {
+        $parameter = new ParameterDefinition('foo');
+
+        $this->assertFalse($parameter->hasDefaultValue());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Default value is not set for "foo".');
+
+        $parameter->getDefaultValue();
+    }
+}


### PR DESCRIPTION
`ParameterDefinition` is for defining parameters (obviously) .. but really - it is for defining parameters of functions you are implementing for ApiFilter.

This will be used in registering functions (_which will come later_), like this:
```php
$apiFilter->declareFunction(
    'fullName',
    [new ParameterDefinition('firstName'), new ParameterDefinition('surname')]
)
```

which means, you are declaring a function `fullName` with two parameters `firstName` and `surname` where both of the parameters will be executed as `equals` (_default_) filter on columns `firstName` and `surname`

There will be more ways to define parameters, but as I said it will come later ...