### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "phpstan": "vendor/bin/phpstan analyze ./src ./tests -c phpstan.neon --ansi --level 7",
         "tests": "vendor/bin/phpunit",
         "tests-ci": "mkdir -p reports && php -dxdebug.coverage_enable=1 vendor/bin/phpunit -c phpunit.xml.dist",
-        "cs": "vendor/bin/ecs check -vvv --ansi src/ tests/",
-        "fix": "vendor/bin/ecs check -vvv --ansi --clear-cache --fix src/ tests/"
+        "cs": "vendor/bin/ecs check -vv --ansi src/ tests/",
+        "fix": "vendor/bin/ecs check -vv --ansi --clear-cache --fix src/ tests/"
     }
 }

--- a/tests/ApiFilterTest.php
+++ b/tests/ApiFilterTest.php
@@ -194,12 +194,12 @@ class ApiFilterTest extends AbstractTestCase
         return [
             // invalidQueryParameters, expectedMessage
             'empty filter' => [
-                ['column' => ['' => 'value']],
-                'Filter "" is not implemented. For column "column" with value "value".',
+                ['column' => ['' => 'foo']],
+                'Filter "" is not implemented. For column "column" with value "foo".',
             ],
             'unknown filter' => [
-                ['column' => ['unknown' => 'value']],
-                'Filter "unknown" is not implemented. For column "column" with value "value".',
+                ['column' => ['unknown' => 'foo']],
+                'Filter "unknown" is not implemented. For column "column" with value "foo".',
             ],
             'tuples in IN filter' => [
                 ['(id, name)' => ['in' => ['(1,one)', '(2,two)']]],

--- a/tests/Service/Parser/AbstractParserTestCase.php
+++ b/tests/Service/Parser/AbstractParserTestCase.php
@@ -25,27 +25,27 @@ abstract class AbstractParserTestCase extends AbstractTestCase
     protected const CASE_SCALAR_COLUMN_AND_SCALAR_VALUE = [
         'scalar column + scalar value' => [
             'column',
-            'value',
+            'foo',
             [
-                ['column', 'eq', 'value'],
+                ['column', 'eq', 'foo'],
             ],
         ],
     ];
     protected const CASE_SCALAR_COLUMN_AND_ARRAY_VALUE = [
         'scalar column + array value' => [
             'column',
-            ['gt' => 'value'],
+            ['gt' => 'foo'],
             [
-                ['column', 'gt', 'value'],
+                ['column', 'gt', 'foo'],
             ],
         ],
     ];
     protected const CASE_SCALAR_COLUMN_AND_ARRAY_VALUES = [
         'scalar column + array values' => [
             'column',
-            ['gte' => 'value', 'lte' => 'value2'],
+            ['gte' => 'value1', 'lte' => 'value2'],
             [
-                ['column', 'gte', 'value'],
+                ['column', 'gte', 'value1'],
                 ['column', 'lte', 'value2'],
             ],
         ],
@@ -70,9 +70,9 @@ abstract class AbstractParserTestCase extends AbstractTestCase
     protected const CASE_TUPLE_COLUMN_AND_TUPLE_VALUE_IMPLICIT_FILTERS = [
         'implicit filters in tuple column + value' => [
             '(col1,col2)',
-            '(value,[min;max])',
+            '(foo,[min;max])',
             [
-                ['col1', 'eq', 'value'],
+                ['col1', 'eq', 'foo'],
                 ['col2', 'in', ['min', 'max']],
             ],
         ],
@@ -100,7 +100,7 @@ abstract class AbstractParserTestCase extends AbstractTestCase
     protected const CASE_TUPLE_COLUMN_AND_SCALAR_VALUE = [
         'tuple column + scalar value' => [
             '(col1,col2)',
-            'value',
+            'foo',
             [], // not supported atm
         ],
     ];

--- a/tests/Service/QueryParametersParserTest.php
+++ b/tests/Service/QueryParametersParserTest.php
@@ -275,20 +275,20 @@ class QueryParametersParserTest extends AbstractTestCase
         return [
             // queryParameters, expected message
             'empty filter' => [
-                ['column' => ['' => 'value']],
-                'Filter "" is not implemented. For column "column" with value "value".',
+                ['column' => ['' => 'foo']],
+                'Filter "" is not implemented. For column "column" with value "foo".',
             ],
             'unknown filter' => [
-                ['column' => ['unknown' => 'value']],
-                'Filter "unknown" is not implemented. For column "column" with value "value".',
+                ['column' => ['unknown' => 'foo']],
+                'Filter "unknown" is not implemented. For column "column" with value "foo".',
             ],
             'undefined function' => [
                 ['function' => '(arg1, arg2)'],
                 'Explicit function definition by values must be an array of functions. (arg1, arg2) given.',
             ],
             'tuple columns and a single value' => [
-                ['(col1, col2)' => 'value'],
-                'Invalid combination of a tuple and a scalar. Column (col1, col2) and value value.',
+                ['(col1, col2)' => 'foo'],
+                'Invalid combination of a tuple and a scalar. Column (col1, col2) and value foo.',
             ],
             'more columns than values' => [
                 ['(col1, col2, col3)' => '(val1, val2)'],


### PR DESCRIPTION
Some dependency introduced `value` function, which destroyed all tests, where simple `value` string was used to be a not-callable string